### PR TITLE
feat: add metrics collector and fix CLI import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.py[cod]
+.pytest_cache/
+pytest_cache/
+*.log

--- a/src/cli/btc_trading_cli.py
+++ b/src/cli/btc_trading_cli.py
@@ -27,7 +27,7 @@ try:
     from ..sentiment.enhanced_sentiment_analyzer import EnhancedSentimentAnalyzer
     from ..trading.bitcoin_trading_system_with_ollama import BitcoinTradingSystemWithOllama
     from ..core.sentiment_benchmark import SentimentBenchmark
-    from metrics_collector import metrics_collector
+    from ..utils.metrics_collector import metrics_collector
 except ImportError as e:
     click.echo(f"❌ Erro importando módulos: {e}", err=True)
     click.echo("Certifique-se de que está no diretório correto e que o sistema está instalado.", err=True)

--- a/src/utils/metrics_collector.py
+++ b/src/utils/metrics_collector.py
@@ -1,0 +1,110 @@
+import json
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Dict, List, Optional
+
+
+@dataclass
+class AlertRule:
+    metric: str
+    condition: str  # 'gt' or 'lt'
+    threshold: float
+    severity: str
+    message: str
+
+
+class MetricsCollector:
+    """Simple in-memory metrics collector with optional persistence."""
+
+    def __init__(self, storage_file: Optional[Path] = None):
+        self.storage_file = storage_file or (
+            Path.home() / '.btc-trading' / 'metrics.json'
+        )
+        self.metrics: List[Dict] = []
+        self.alerts: List[Dict] = []
+        self.rules: List[AlertRule] = []
+        self.storage_file.parent.mkdir(parents=True, exist_ok=True)
+        self._load()
+
+    # ------------------------------------------------------------------
+    def _load(self) -> None:
+        if self.storage_file.exists():
+            try:
+                data = json.loads(self.storage_file.read_text())
+                self.metrics = data.get('metrics', [])
+                self.alerts = data.get('alerts', [])
+            except Exception:
+                # Se falhar ao carregar, iniciar vazio
+                self.metrics = []
+                self.alerts = []
+
+    def _save(self) -> None:
+        try:
+            data = {'metrics': self.metrics, 'alerts': self.alerts}
+            self.storage_file.write_text(json.dumps(data, indent=2))
+        except Exception:
+            pass  # Não interromper fluxo se salvar falhar
+
+    # ------------------------------------------------------------------
+    def add_alert_rule(
+        self,
+        metric: str,
+        condition: str,
+        threshold: float,
+        severity: str,
+        message: str,
+    ) -> None:
+        self.rules.append(
+            AlertRule(metric, condition, threshold, severity, message)
+        )
+
+    def record_metric(
+        self, name: str, value: float, unit: Optional[str] = None
+    ) -> None:
+        entry = {
+            'timestamp': datetime.utcnow().isoformat(),
+            'name': name,
+            'value': value
+        }
+        if unit:
+            entry['unit'] = unit
+        self.metrics.append(entry)
+        self._check_alerts(name, value)
+        self._save()
+
+    # ------------------------------------------------------------------
+    def _check_alerts(self, name: str, value: float) -> None:
+        for rule in self.rules:
+            if rule.metric != name:
+                continue
+            triggered = False
+            if rule.condition == 'gt' and value > rule.threshold:
+                triggered = True
+            elif rule.condition == 'lt' and value < rule.threshold:
+                triggered = True
+            if triggered:
+                self.alerts.append({
+                    'timestamp': datetime.utcnow().isoformat(),
+                    'metric': name,
+                    'value': value,
+                    'severity': rule.severity,
+                    'message': rule.message
+                })
+
+    # ------------------------------------------------------------------
+    def get_recent_alerts(self, hours: int = 24) -> List[Dict]:
+        cutoff = datetime.utcnow() - timedelta(hours=hours)
+        recent = []
+        for alert in self.alerts:
+            try:
+                ts = datetime.fromisoformat(alert['timestamp'])
+            except Exception:
+                continue
+            if ts >= cutoff:
+                recent.append(alert)
+        return sorted(recent, key=lambda x: x['timestamp'], reverse=True)
+
+
+# Instância global usada pela CLI
+metrics_collector = MetricsCollector()


### PR DESCRIPTION
## Summary
- add reusable metrics collector with alert rules and JSON persistence
- fix CLI to import metrics collector from new utils module
- ignore Python cache and log files

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8 src/utils/metrics_collector.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688c201edef4832caacce375f04f4944